### PR TITLE
Introduces a fix for recover deleted object view.

### DIFF
--- a/aldryn_reversion/admin.py
+++ b/aldryn_reversion/admin.py
@@ -30,6 +30,7 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,
                                      reversion.VersionAdmin):
     revision_confirmation_template = 'aldryn_reversion/confirm_reversion.html'
     recover_confirmation_template = 'aldryn_reversion/confirm_recover.html'
+
     def add_plugin(self, request):
         with transaction.atomic():
             with reversion.create_revision():
@@ -201,7 +202,7 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,
         # check if we need to restore placeholder fields
         object_placeholders = get_deleted_placeholders_for_object(obj, revision)
         # FIXME: Not heavily tested yet
-        if len(non_reversible_by_user) > 1:
+        if len(non_reversible_by_user) > 0:
             to_resolve = resolve_conflicts(
                 non_reversible_by_user[0], non_reversible_by_user[1:])
             non_reversible_by_user = set(to_resolve)
@@ -240,7 +241,7 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,
                     args=(pk_value,),
                     current_app=self.admin_site.name
                 )
-                # FIXME: Check if there is next parameter and redirect to
+                # TODO: Check if there is next parameter and redirect to
                 # next, for cases of conflict solving.
                 redirect_url = add_preserved_filters({
                     'preserved_filters': preserved_filters,
@@ -250,7 +251,7 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,
         else:
             # populate form with regular data
             form = RecoverObjectWithTranslationForm(**restore_form_kwargs)
-        # FIXME: remove unused.
+
         context = {
             'object': obj,
             'version': version,

--- a/aldryn_reversion/admin.py
+++ b/aldryn_reversion/admin.py
@@ -161,8 +161,7 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,
                                       context, RequestContext(request))
 
     @transaction.atomic
-    def recover_view(self, request, version_id,
-                      extra_context=None):
+    def recover_view(self, request, version_id, extra_context=None):
         if not self.has_change_permission(request):
             raise PermissionDenied()
 

--- a/aldryn_reversion/admin.py
+++ b/aldryn_reversion/admin.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, NoReverseMatch
 from django.contrib import messages
 from django.contrib.admin.util import unquote
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
@@ -19,12 +19,14 @@ import reversion
 from reversion.models import Version
 
 from .core import create_revision_with_placeholders
+from .forms import RecoverObjectWithTranslationForm
+from .utils import get_conflict_fks_versions
 
 
 class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,
                                      reversion.VersionAdmin):
     revision_confirmation_template = 'aldryn_reversion/confirm_reversion.html'
-
+    recover_confirmation_template = 'aldryn_reversion/confirm_recover.html'
     def add_plugin(self, request):
         with transaction.atomic():
             with reversion.create_revision():
@@ -153,3 +155,109 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,
             }
             return render_to_response(self.revision_confirmation_template,
                                       context, RequestContext(request))
+
+    @transaction.atomic
+    def recover_view(self, request, version_id,
+                      extra_context=None):
+        if not self.has_change_permission(request):
+            raise PermissionDenied()
+
+        version = get_object_or_404(Version, pk=unquote(version_id))
+        obj = version.object_version.object
+        revision = version.revision
+
+        # check for conflicts, it is better that user would solve them
+        conflict_fks_versions = get_conflict_fks_versions(
+            obj, version, revision)
+
+        # build urls to point user onto restore links for conflicts
+        opts = self.model._meta
+        non_reversable_by_user = []
+        conflicts_links_to_restore = []
+        for fk_version in conflict_fks_versions:
+            # try to point user to conflict recover views
+            # FIXME: make links human friendly
+            try:
+                link = reverse(
+                    'admin:{0}_{1}_recover'.format(
+                        opts.app_label,
+                        fk_version.object_version.object._meta.model_name),
+                    args=[fk_version.pk])
+            except NoReverseMatch:
+                # if there is exception either model is not registered
+                # with VersionedPlaceholderAdminMixin or there is no admin
+                # for that model. In both cases we need to revert this object
+                # to avoid conflicts / integrety errors
+                non_reversable_by_user.append(fk_version)
+            else:
+                conflicts_links_to_restore.append(link)
+
+        if request.method == "POST":
+            form = RecoverObjectWithTranslationForm(
+                request.POST, revision=revision, obj=obj, version=version,
+                resolve_conflicts=non_reversable_by_user)
+            # form.is_valid would perform validation against foreign keys
+            if form.is_valid():
+                # form save will restore desired versions for object and its
+                # translations
+                form.save()
+                # FIXME: optimize response
+                opts = self.model._meta
+                pk_value = obj._get_pk_val()
+                preserved_filters = self.get_preserved_filters(request)
+
+                msg_dict = {
+                    'name': force_text(opts.verbose_name),
+                    'obj': force_text(obj)
+                }
+                msg = _('The %(name)s "%(obj)s" was successfully recovered. '
+                        'You may edit it again below.') % msg_dict
+                self.message_user(request, msg, messages.SUCCESS)
+                redirect_url = reverse(
+                    'admin:%s_%s_change' % (opts.app_label, opts.model_name),
+                    args=(pk_value,),
+                    current_app=self.admin_site.name
+                )
+                # FIXME: Check if there is next parameter and redirect to
+                # next, for cases of conflict solving.
+                redirect_url = add_preserved_filters({
+                    'preserved_filters': preserved_filters,
+                    'opts': opts,
+                }, redirect_url)
+                return HttpResponseRedirect(redirect_url)
+        else:
+            # populate form with regular data
+            form = RecoverObjectWithTranslationForm(
+                revision=revision, obj=obj, version=version,
+                resolve_conflicts=non_reversable_by_user)
+        # FIXME: remove unused.
+        context = {
+            'object': obj,
+            'version': version,
+            'revision': revision,
+            'revision_date': revision.date_created,
+            'conflicts': bool(conflict_fks_versions),
+            'conflict_links': conflicts_links_to_restore,
+            'non_resolvable_conflicts': non_reversable_by_user,
+            'versions': revision.version_set.order_by(
+                'content_type__name', 'object_id_int').all,
+            'object_name': force_text(self.model._meta.verbose_name),
+            'app_label': self.model._meta.app_label,
+            'opts': self.model._meta,
+            'add': False,
+            'change': True,
+            'save_as': False,
+            'has_add_permission': self.has_add_permission(request),
+            'has_change_permission': self.has_change_permission(
+                request, obj),
+            'has_delete_permission': self.has_delete_permission(
+                request, obj),
+            'has_file_field': True,
+            'has_absolute_url': False,
+            'original': obj,
+        }
+        # if there is no conflicts - add form to context.
+        if not conflict_fks_versions:
+            context['restore_form'] = form
+        return render_to_response(self.recover_confirmation_template,
+                                  context, RequestContext(request))

--- a/aldryn_reversion/forms.py
+++ b/aldryn_reversion/forms.py
@@ -1,0 +1,68 @@
+from django.core.exceptions import ValidationError
+from django.forms import forms
+from django.forms.fields import MultipleChoiceField
+from django.forms.widgets import CheckboxSelectMultiple
+from django.utils.encoding import force_text
+
+from .utils import (
+    get_translations_versions_for_object, get_conflict_fks_versions
+)
+
+
+class RecoverObjectWithTranslationForm(forms.Form):
+    translations = MultipleChoiceField(
+        widget=CheckboxSelectMultiple(),
+        help_text='Please select translations to restore.',
+        required=True)
+
+    def __init__(self, *args, **kwargs):
+        # prepare data for misc lookups
+        self.revision = kwargs.pop('revision')
+        self.obj = kwargs.pop('obj')
+        self.obj_version = kwargs.pop('version')
+        self.resolve_conflicts = kwargs.pop('resolve_conflicts')
+        # do not check object which needs to be recovered
+        versions = self.revision.version_set.exclude(pk=self.obj_version.pk)
+
+        super(RecoverObjectWithTranslationForm, self).__init__(*args, **kwargs)
+
+        translatable = hasattr(self.obj, 'translations')
+        if translatable:
+            translation_versions = get_translations_versions_for_object(
+                self.obj, self.revision, versions)
+            # update form
+            self.fields['translations'] = MultipleChoiceField(
+                widget=CheckboxSelectMultiple(),
+                choices=[
+                    (translation_version.pk, force_text(translation_version))
+                    for translation_version in translation_versions])
+        else:
+            # do not show translations options if object is not translated
+            self.fields.pop('translations')
+
+    def clean(self):
+        data = super(RecoverObjectWithTranslationForm, self).clean()
+        # if there is self.resolve_conflicts do not count them as conflicts
+        exclude = {'pk__in': [version.pk for version in self.resolve_conflicts]}
+        conflict_fks_versions = get_conflict_fks_versions(
+            self.obj, self.obj_version, self.revision,
+            exclude=exclude)
+        if bool(conflict_fks_versions):
+            raise ValidationError('Cannot restore object, there is conflicts!',
+                                  code='invalid')
+        return data
+
+    def save(self):
+        # if there is self.resolve_conflicts revert those objects to avoid
+        # integrity errors, because user cannot do that form admin
+        # FIXME: Not tested yet
+        for conflict in self.resolve_conflicts:
+            conflict.revert()
+        # revert main object
+        self.obj_version.revert()
+        # revert translations, if there is translations
+        translations_pks = self.cleaned_data.get('translations', [])
+        translation_versions = self.revision.version_set.filter(
+            pk__in=translations_pks)
+        for translation_version in translation_versions:
+            translation_version.revert()

--- a/aldryn_reversion/templates/aldryn_reversion/confirm_recover.html
+++ b/aldryn_reversion/templates/aldryn_reversion/confirm_recover.html
@@ -21,26 +21,35 @@
         {% endblocktrans %}
     </p>
 
-    {% if non_resolvable_conflicts %}
-        <h3>Following conflicts would be recovered automaticly</h3>
+    {% if placeholders_to_restore %}
+        <p>{% trans 'Following placeholders were deleted and will be restored:' %}</p>
         <ul>
-            {% for conflict in non_resolvable_conflicts %}
-                <li>{{ conflict.content_type.name|capfirst }} #{{ conflict.object_id_int }}: {{ conflict.object_repr }}</li>
+            {% for placeholder_version in placeholders_to_restore %}
+                <li>{{ placeholder_version.content_type.name|capfirst }} #{{ placeholder_version.object_id_int }}: {{ placeholder_version.object_repr }}</li>
             {% endfor %}
         </ul>
     {% endif %}
 
     {% if conflicts %}
-        <h3>Warning there is conflicts</h3>
-        <p>Please restore required related objects first</p>
+        <h3>{% trans 'Warning there is conflicts' %}</h3>
+        <p>{% trans 'Please restore required related objects first:' %}</p>
         <ul>
-            {% for conflict_link in conflict_links %}
-                <li><a href="{{ conflict_link }}">{{ conflict_link }}</a></li>
+            {% for conflict in conflict_links %}
+                <li><a href="{{ conflict.link }}">{{ conflict.version.content_type.name|capfirst }} #{{ conflict.version.object_id_int }}: {{ conflict.version.object_repr }}</a></li>
             {% endfor %}
         </ul>
     {% endif %}
 
     {% if restore_form %}
+        {% if non_resolvable_conflicts %}
+            <h3>{% trans 'Following conflicts would be recovered automatically' %}</h3>
+            <ul>
+                {% for conflict in non_resolvable_conflicts %}
+                    <li>{{ conflict.content_type.name|capfirst }} #{{ conflict.object_id_int }}: {{ conflict.object_repr }}</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+
         <form action="" method="post">
             {% csrf_token %}
             {{ restore_form.as_p }}

--- a/aldryn_reversion/templates/aldryn_reversion/confirm_recover.html
+++ b/aldryn_reversion/templates/aldryn_reversion/confirm_recover.html
@@ -1,0 +1,55 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} revert-confirmation{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% trans "Home" %}</a> &rsaquo;
+        <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a> &rsaquo;
+        <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst|escape }}</a> &rsaquo;
+        <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ object|truncatewords:"18" }}</a> &rsaquo;
+        <a href="../">{% trans "History" %}</a> &rsaquo;
+        {% blocktrans with opts.verbose_name as verbose_name %}Restore deleted {{ verbose_name }}{% endblocktrans %}
+    </div>
+{% endblock %}
+
+{% block content %}
+    <p>
+        {% blocktrans with escaped_object=object %}
+            Are you sure you want to restore the {{ object_name }} "{{ escaped_object }}" to its version of {{ revision_date }}?
+        {% endblocktrans %}
+    </p>
+
+    {% if non_resolvable_conflicts %}
+        <h3>Following conflicts would be recovered automaticly</h3>
+        <ul>
+            {% for conflict in non_resolvable_conflicts %}
+                <li>{{ conflict.content_type.name|capfirst }} #{{ conflict.object_id_int }}: {{ conflict.object_repr }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+
+    {% if conflicts %}
+        <h3>Warning there is conflicts</h3>
+        <p>Please restore required related objects first</p>
+        <ul>
+            {% for conflict_link in conflict_links %}
+                <li><a href="{{ conflict_link }}">{{ conflict_link }}</a></li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+
+    {% if restore_form %}
+        <form action="" method="post">
+            {% csrf_token %}
+            {{ restore_form.as_p }}
+            <div>
+                <input type="hidden" name="post" value="yes" />
+                <input type="submit" value="{% trans "Yes, I'm sure" %}" />
+                <a href="#" onclick="window.history.back(); return false;" class="button cancel-link">{% trans "No, take me back" %}</a>
+            </div>
+        </form>
+    {% endif %}
+
+{% endblock %}

--- a/aldryn_reversion/templates/aldryn_reversion/confirm_recover.html
+++ b/aldryn_reversion/templates/aldryn_reversion/confirm_recover.html
@@ -17,12 +17,12 @@
 {% block content %}
     <p>
         {% blocktrans with escaped_object=object %}
-            Are you sure you want to restore the {{ object_name }} "{{ escaped_object }}" to its version of {{ revision_date }}?
+            Are you sure you want to restore the {{ object_name }} "{{ escaped_object }}" to its version from {{ revision_date }}?
         {% endblocktrans %}
     </p>
 
     {% if placeholders_to_restore %}
-        <p>{% trans 'Following placeholders were deleted and will be restored:' %}</p>
+        <p>{% trans 'The following placeholders were deleted and will be restored:' %}</p>
         <ul>
             {% for placeholder_version in placeholders_to_restore %}
                 <li>{{ placeholder_version.content_type.name|capfirst }} #{{ placeholder_version.object_id_int }}: {{ placeholder_version.object_repr }}</li>
@@ -31,7 +31,7 @@
     {% endif %}
 
     {% if conflicts %}
-        <h3>{% trans 'Warning there is conflicts' %}</h3>
+        <h3>{% trans 'Warning there are conflicts' %}</h3>
         <p>{% trans 'Please restore required related objects first:' %}</p>
         <ul>
             {% for conflict in conflict_links %}
@@ -42,7 +42,7 @@
 
     {% if restore_form %}
         {% if non_resolvable_conflicts %}
-            <h3>{% trans 'Following conflicts would be recovered automatically' %}</h3>
+            <h3>{% trans 'The following conflicts would be recovered automatically' %}</h3>
             <ul>
                 {% for conflict in non_resolvable_conflicts %}
                     <li>{{ conflict.content_type.name|capfirst }} #{{ conflict.object_id_int }}: {{ conflict.object_repr }}</li>

--- a/aldryn_reversion/templates/aldryn_reversion/confirm_recover.html
+++ b/aldryn_reversion/templates/aldryn_reversion/confirm_recover.html
@@ -8,7 +8,7 @@
         <a href="{% url 'admin:index' %}">{% trans "Home" %}</a> &rsaquo;
         <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a> &rsaquo;
         <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst|escape }}</a> &rsaquo;
-        <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ object|truncatewords:"18" }}</a> &rsaquo;
+        <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ version.object_repr|truncatewords:"18" }}</a> &rsaquo;
         <a href="../">{% trans "History" %}</a> &rsaquo;
         {% blocktrans with opts.verbose_name as verbose_name %}Restore deleted {{ verbose_name }}{% endblocktrans %}
     </div>
@@ -16,7 +16,7 @@
 
 {% block content %}
     <p>
-        {% blocktrans with escaped_object=object %}
+        {% blocktrans with escaped_object=version.object_repr %}
             Are you sure you want to restore the {{ object_name }} "{{ escaped_object }}" to its version from {{ revision_date }}?
         {% endblocktrans %}
     </p>

--- a/aldryn_reversion/utils.py
+++ b/aldryn_reversion/utils.py
@@ -103,18 +103,22 @@ def get_deleted_placeholders(revision):
 
 def get_deleted_placeholders_for_object(obj, revision):
     """
-    Return deleted placeholders
+    Return deleted placeholders for object given
     """
     if object_has_placeholders(obj):
 
         placeholders_versions = get_deleted_placeholders(revision)
-        # add only placeholders that belong to this object
-        placeholders_pks = [getattr(obj, field_name).pk
+        # add only placeholders that belong to this object,
+        # accessing field_name itself refers to deleted object, but _id isn't.
+        # Other approach would be to load object_repr and get data from there
+        placeholders_pks = [getattr(obj, '{0}_id'.format(field_name))
                             for field_name in get_placeholder_fields_names(obj)
-                            if getattr(obj, field_name, None) is not None]
+                            if getattr(obj,
+                                       '{0}_id'.format(field_name),
+                                       None) is not None]
         return [placeholder_version
                 for placeholder_version in placeholders_versions
-                if placeholder_version.pk in placeholders_pks]
+                if placeholder_version.object_id_int in placeholders_pks]
     return []
 
 

--- a/aldryn_reversion/utils.py
+++ b/aldryn_reversion/utils.py
@@ -1,0 +1,74 @@
+from django.contrib.contenttypes.models import ContentType
+from django.db.models.fields.related import ForeignKey
+
+
+def get_translations_versions_for_object(obj, revision, versions=None):
+    """
+    Returns a queryset of translation versions for given object, if versions
+    provided - performs lookup on them instead of revision.version_set.all().
+    """
+    translatable = hasattr(obj, 'translations')
+    if not translatable:
+        return []
+
+    if versions is None:
+        versions = revision.version_set.all()
+    # get translations versions
+    translation_model = obj.translations.model
+    translation_ct = ContentType.objects.get_for_model(translation_model)
+    translation_version = versions.filter(content_type=translation_ct)
+    return translation_version
+
+
+def get_required_fk_models(obj):
+    """
+    Returns required (blank=False) FK models for given object.
+    """
+    fk_fields = [fk for fk in obj._meta.fields if type(fk) == ForeignKey]
+    required_fks_models = [fk.rel.to for fk in fk_fields if not fk.blank]
+    return required_fks_models
+
+
+def get_deleted_objects_versions(revision, versions=None,
+                                 exclude=None):
+    """
+    Returns a list of version for deleted objects in given versions queryset,
+    or revision.version_set.all() if versions queryset is not provided.
+    Performs excluding on versions queryset if exclude dictionary
+    (field_name, value) is provided.
+    """
+    other_deleted = []
+    if versions is None:
+        revision.version_set.all()
+
+    if exclude is not None:
+        versions.exclude(**exclude)
+    for version in versions:
+        if version.object is None:
+            # if there is no relation to object - it is delted
+            other_deleted.append(version)
+            continue
+        # get object model class to access database for lookup
+        check_obj_model = version.object._meta.model
+        # if there is a match - object exists and we don't need to
+        # restore it
+        exists = check_obj_model.objects.filter(pk=version.object_id)
+        if len(exists) > 0:
+            continue
+        other_deleted.append(version)
+    return other_deleted
+
+
+def get_conflict_fks_versions(obj, version, revision, exclude=None):
+    """
+    Lookup for deleted FKs for object
+    Returns versions for deleted fks.
+    """
+    required_models = get_required_fk_models(obj)
+    required_cts = [ContentType.objects.get_for_model(
+        fk_model) for fk_model in required_models]
+    versions_to_check = revision.version_set.exclude(
+        pk=version.pk).filter(content_type__in=required_cts)
+    conflict_fks_versions = get_deleted_objects_versions(
+        revision, versions=versions_to_check, exclude=exclude)
+    return conflict_fks_versions


### PR DESCRIPTION
Introduces recover view.
Since default `django-revisions` view does not respects translations. Actually it doesn't restores object, instead it gets and populates admin form for that object with data from selected object version. Because of that all related objects are missing, and i couldn't find a way to restore all translations with that method, though we can populate with translations for one language.

Instead of populating that form - PR introduces override of recover view from `django-reversions` in similar way that revision_view is introduced before.

View tries:
* to check if there is dependency (deleted object that is referenced by FK field and it is not blank=True)
    * if there is dependency that user can revert by himself - displays a link to revert that object
    * if link cannot be build - assumes that `VersionedPlaceholderAdminMixin` is not used, and adds that for automatic resolve trials.
* If there is no conflicts or there is only conflicts that can be resolved automatically - gets translations for object and allows user to choose which of them should be recovered (at least one should be selected)

* tries to revert version of object and versions of required related objects that are marked as non user resolvable. For non user resolvable conflicts restores all found translations
* Also if objects had placeholder fields - restores them if they were deleted.

* Uses revision for top level (initial object that was selected for recover process) for solving conflicts. can be changed to use most recent revision by using `reversion.get_unique_for_object` utility method

Was tested with `aldryn-jobs` pre 1.0.0, with different mixing of `VersionedPlaceholderAdminMixin` for FK fields.