### PR TITLE
Log deletion of translation, verbose messages to history view.

### DIFF
--- a/aldryn_reversion/admin.py
+++ b/aldryn_reversion/admin.py
@@ -116,14 +116,16 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,
             db=self.revision_context_manager.get_db(),
         )
 
-    def log_change(self, request, obj, message):
+    def log_change(self, request, obj, message, deletion=False):
         # prepare correct change message so that we can distinguish which
         # revision would be restored. if object has language code - apppend
-        # it to the message
-        new_message = u"{0} {1}{2}".format(
-            message, build_obj_repr(obj), get_translation_info_message(obj))
+        # it to the message, but if previous operation was translation deletion
+        # do not modify the message, it is already prepared.
+        if not deletion:
+            message = u"{0} {1}{2}".format(
+                message, build_obj_repr(obj), get_translation_info_message(obj))
         super(VersionedPlaceholderAdminMixin, self).log_change(
-            request, obj, new_message)
+            request, obj, message)
 
     # TODO: extract to separate translation admin mixin
     def log_deletion(self, request, obj, object_repr):
@@ -142,7 +144,7 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,
             "Translation deletion for {0} ('{1}' language).".format(
                 build_obj_repr(obj.master), obj.language_code.upper())
         )
-        self.log_change(request, obj.master, message)
+        self.log_change(request, obj.master, message, deletion=True)
 
     @transaction.atomic
     def revision_view(self, request, object_id, version_id,

--- a/aldryn_reversion/utils.py
+++ b/aldryn_reversion/utils.py
@@ -3,6 +3,18 @@ from django.db.models.fields.related import ForeignKey
 import cms.models
 
 
+def object_is_translation(obj):
+    """
+    Returns True if object is translation object.
+    """
+    related_name = getattr(obj, 'related_name', None)
+    if related_name is None:
+        return False
+    if related_name != u'translations':
+        return False
+    return True
+
+
 def get_translations_versions_for_object(obj, revision, versions=None):
     """
     Returns a queryset of translation versions for given object, if versions

--- a/aldryn_reversion/utils.py
+++ b/aldryn_reversion/utils.py
@@ -1,5 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.fields.related import ForeignKey
+from django.utils.encoding import force_text
 import cms.models
 
 
@@ -13,6 +14,26 @@ def object_is_translation(obj):
     if related_name != u'translations':
         return False
     return True
+
+
+def build_obj_repr(obj):
+    """
+    Returns a unicode string of object Model name and its text representation.
+    """
+    return u"{0}: '{1}'".format(force_text(obj._meta.model.__name__),
+                                force_text(obj))
+
+
+def get_translation_info_message(obj):
+    """
+    Prepares a simple translation info message i.e " ('EN' translation)"
+    for given object, or an empty string.
+    """
+    language_message = u''
+    if getattr(obj, 'language_code', None) is not None:
+        language_message = u" ('{0}' translation)".format(
+            obj.language_code.upper())
+    return language_message
 
 
 def get_translations_versions_for_object(obj, revision, versions=None):

--- a/aldryn_reversion/utils.py
+++ b/aldryn_reversion/utils.py
@@ -1,6 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.fields.related import ForeignKey
 from django.utils.encoding import force_text
+from django.utils.translation import ugettext as _
+
 import cms.models
 
 
@@ -11,7 +17,7 @@ def object_is_translation(obj):
     related_name = getattr(obj, 'related_name', None)
     if related_name is None:
         return False
-    if related_name != u'translations':
+    if related_name != 'translations':
         return False
     return True
 
@@ -20,7 +26,7 @@ def build_obj_repr(obj):
     """
     Returns a unicode string of object Model name and its text representation.
     """
-    return u"{0}: '{1}'".format(force_text(obj._meta.model.__name__),
+    return "{0}: '{1}'".format(force_text(obj._meta.model.__name__),
                                 force_text(obj))
 
 
@@ -29,10 +35,10 @@ def get_translation_info_message(obj):
     Prepares a simple translation info message i.e " ('EN' translation)"
     for given object, or an empty string.
     """
-    language_message = u''
+    language_message = ''
     if getattr(obj, 'language_code', None) is not None:
-        language_message = u" ('{0}' translation)".format(
-            obj.language_code.upper())
+        language_message = _(" ('%(language_code)s' translation)") % {
+            'language_code': obj.language_code.upper()}
     return language_message
 
 


### PR DESCRIPTION
Tested only with `aldryn-jobs`.
Adds verbose messages to history view, logs deletion of translation in history view.

Verbose messages are needed because if we follow relations - for each object in hierarchy of relations that would be followed new row would be added to history view and messages are not informative, which makes it difficult to use...