### PR TITLE
Django 1.8: small fix for revision view.

### DIFF
--- a/aldryn_reversion/admin.py
+++ b/aldryn_reversion/admin.py
@@ -200,7 +200,7 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,
                 'revision': revision,
                 'revision_date': revision.date_created,
                 'versions': revision.version_set.order_by(
-                    'content_type__name', 'object_id_int').all,
+                    'content_type__model', 'object_id_int').all,
                 'object_name': force_text(self.model._meta.verbose_name),
                 'app_label': self.model._meta.app_label,
                 'opts': self.model._meta,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from aldryn_reversion import __version__
 
 REQUIREMENTS = [
     'django-cms>=3.0.12',
-    'django-reversion>=1.8.2,<1.9',
+    'django-reversion>=1.8.2,<1.10',
     'django-parler>=1.4',
 ]
 

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -1,4 +1,4 @@
 django>=1.8,<1.9
-django-reversion>=1.8.2,<1.9
+django-reversion>=1.9.3,<1.10
 
 -r base.txt

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+from distutils.version import LooseVersion
+from django import get_version
+
+django_version = LooseVersion(get_version())
 
 HELPER_SETTINGS = {
     'INSTALLED_APPS': [
@@ -40,6 +44,34 @@ HELPER_SETTINGS = {
         }
     },
 }
+
+if django_version >= LooseVersion('1.8.0'):
+    HELPER_SETTINGS.update({
+        'TEMPLATES': [
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'OPTIONS': {
+                    'context_processors': [
+                        'django.contrib.auth.context_processors.auth',
+                        'django.contrib.messages.context_processors.messages',
+                        'django.core.context_processors.i18n',
+                        'django.core.context_processors.debug',
+                        'django.core.context_processors.request',
+                        'django.core.context_processors.media',
+                        'django.core.context_processors.csrf',
+                        'django.core.context_processors.tz',
+                        'sekizai.context_processors.sekizai',
+                        'django.core.context_processors.static',
+                        'cms.context_processors.cms_settings',
+                    ],
+                    'loaders': [
+                        'django.template.loaders.filesystem.Loader',
+                        'django.template.loaders.app_directories.Loader',
+                    ],
+                },
+            },
+        ]
+    })
 
 
 def run():


### PR DESCRIPTION
Changes that are needed to support Django 1.8. 
* Changes to test_settings,
* Fix for changes in django ContentType model
Tests are passing.
Heavily relies on django-reversions Django 1.8 support (1.9.3)