### PR TITLE
Compatibility: reversion 1.9.0, apply fixes to correspond to new django-reversion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+X.X.X (XXXX-XX-XX)
+------------------
+
+* Fix compatibility with django-reversions >=1.9.0
+
 1.0.0 (2015-08-31)
 ------------------
 

--- a/aldryn_reversion/admin.py
+++ b/aldryn_reversion/admin.py
@@ -126,19 +126,11 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,
             "Initial version of %(object_repr)s.%(translation_info)s") % {
                 'object_repr': build_obj_repr(obj),
                 'translation_info': get_translation_info_message(obj)}
-        objects = [obj]
-        # django-reversion >1.9.0 no longer has get_revision_instances
-        # but for supporting older versions we will check for it and use
-        if hasattr(self, 'get_revision_instances'):
-            for additional_object in self.get_revision_instances(
-                    request, obj):
-                if additional_object not in objects:
-                    objects.append(additional_object)
         # previous implementation was to use self.get_revision_data
         # but that was also removed in 1.9.0 since it was a duplicate of logic
         # that is already present in save_revision or its related calls.
         self.revision_manager.save_revision(
-            objects,
+            [obj],
             user=request.user,
             comment=comment,
             ignore_duplicates=self.ignore_duplicate_revisions,

--- a/aldryn_reversion/admin.py
+++ b/aldryn_reversion/admin.py
@@ -130,7 +130,10 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,
         # django-reversion >1.9.0 no longer has get_revision_instances
         # but for supporting older versions we will check for it and use
         if hasattr(self, 'get_revision_instances'):
-            objects += self.get_revision_instances(request, obj)
+            for additional_object in self.get_revision_instances(
+                    request, obj):
+                if additional_object not in objects:
+                    objects.append(additional_object)
         # previous implementation was to use self.get_revision_data
         # but that was also removed in 1.9.0 since it was a duplicate of logic
         # that is already present in save_revision or its related calls.

--- a/aldryn_reversion/admin.py
+++ b/aldryn_reversion/admin.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals
 
-from distutils.version import LooseVersion
-
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.contrib import messages
@@ -27,10 +25,6 @@ from .utils import (
     get_deleted_placeholders_for_object, object_is_translation,
     get_translation_info_message,
 )
-
-# since reversion version is a tuple - convert it to string
-DJANGO_REVERSION_VERSION = LooseVersion(
-    '.'.join([str(num) for num in reversion.version.__version__]))
 
 
 class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin,

--- a/test_settings.py
+++ b/test_settings.py
@@ -6,6 +6,7 @@ django_version = LooseVersion(get_version())
 
 HELPER_SETTINGS = {
     'INSTALLED_APPS': [
+        'djangocms_text_ckeditor',
         'parler',
         'reversion',
         'aldryn_reversion',

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     dj18: -rtest_requirements/django-1.8.txt
     cms30: django-cms<3.1
     cms31: django-cms<3.2
+    djangocms_text_ckeditor
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
Fix for #24, please test on real install, especially with usage of ``aldryn-boilerplates``. (use ``Django 1.8`` and less)

* rename ``_create_revision`` to ``_create_aldryn_reversion``, 
* fix ``get_version_data`` which was removed. 

**Not tested yet.**