### PR TITLE
Django 1.9 support: bump valid django version, update tox/travis envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ sudo: false
 
 env:
   - TOX_ENV=flake8
+  - TOX_ENV=py34-dj19-cms32
   - TOX_ENV=py34-dj18-cms32
   - TOX_ENV=py34-dj18-cms31
   - TOX_ENV=py34-dj17-cms32
   - TOX_ENV=py34-dj17-cms31
   - TOX_ENV=py34-dj17-cms30
+  - TOX_ENV=py27-dj19-cms32
   - TOX_ENV=py27-dj18-cms32
   - TOX_ENV=py27-dj18-cms31
   - TOX_ENV=py27-dj17-cms32

--- a/aldryn_reversion/admin.py
+++ b/aldryn_reversion/admin.py
@@ -96,8 +96,8 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin, VersionAdmin):
         if obj_from_target and object_is_reversion_ready(obj_from_target):
             create_revision(obj_from_target, user=user, comment=comment)
 
-        if (obj_from_source and obj_from_source != obj_from_target
-                and object_is_reversion_ready(obj_from_source)):
+        if (obj_from_source and obj_from_source != obj_from_target and
+                object_is_reversion_ready(obj_from_source)):
             create_revision(obj_from_source, user=user, comment=comment)
 
     def _get_placeholder_attached_object(self, placeholder):

--- a/aldryn_reversion/tests/test_admin_views.py
+++ b/aldryn_reversion/tests/test_admin_views.py
@@ -350,7 +350,8 @@ class ReversionRevisionAdminTestCase(AdminUtilsMixin,
         new_position = 99
         self.create_revision(self.simple_registered, position=new_position)
         self.assertNotEqual(initial_position, self.simple_registered.position)
-        prev_version = default_revision_manager.get_for_object(self.simple_registered)[1]
+        prev_version = default_revision_manager.get_for_object(
+            self.simple_registered)[1]
         response = self.post_revision_veiw_response(
             self.simple_registered, prev_version)
         self.assertEqual(response.status_code, 302)
@@ -376,14 +377,16 @@ class AdminUtilsMethodsTestCase(AdminUtilsMixin,
         plugin.body = 'Initial text'
         plugin.save()
         # ensure there was no versions for plugin before
-        self. assertEqual(default_revision_manager.get_for_object(plugin).count(), 0)
+        self.assertEqual(
+            default_revision_manager.get_for_object(plugin).count(), 0)
         with transaction.atomic():
             with revision_context_manager.create_revision():
                 admin_instance._create_aldryn_revision(
                     plugin.placeholder,
                     comment='New aldryn revision with initial plugin')
         # ensure there is at least one version after create aldryn revision
-        self. assertEqual(default_revision_manager.get_for_object(plugin).count(), 1)
+        self. assertEqual(
+            default_revision_manager.get_for_object(plugin).count(), 1)
         new_plugin_text = 'test plugin content was changed'
         plugin.body = new_plugin_text
         plugin.save()
@@ -394,13 +397,15 @@ class AdminUtilsMethodsTestCase(AdminUtilsMixin,
                     comment='New aldryn revision with initial plugin')
 
         # ensure there is at least one version after create aldryn revision
-        self. assertEqual(default_revision_manager.get_for_object(plugin).count(), 2)
+        self. assertEqual(
+            default_revision_manager.get_for_object(plugin).count(), 2)
         latest_plugin = plugin._meta.model.objects.get(pk=plugin.pk)
 
         # ensure text is latest
         self.assertEqual(latest_plugin.body, new_plugin_text)
         # ensure text is initial if reverted to previous revision
-        prev_version = default_revision_manager.get_for_object(self.with_placeholder)[1]
+        prev_version = default_revision_manager.get_for_object(
+            self.with_placeholder)[1]
         prev_version.revision.revert()
         # refresh from db
         latest_plugin = plugin._meta.model.objects.get(pk=plugin.pk)

--- a/aldryn_reversion/tests/test_placeholders.py
+++ b/aldryn_reversion/tests/test_placeholders.py
@@ -5,11 +5,6 @@ from distutils.version import LooseVersion
 import sys
 import json
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
 from django.contrib import admin
 from django.contrib.contenttypes.models import ContentType
 from django.utils.encoding import force_text
@@ -29,6 +24,11 @@ from .base import (
     CMSRequestBasedMixin,
     ReversionBaseTestCase,
 )
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 # CMS 3.2.1 introduced several fixes for reversions.
 # We count on these fixes in some tests.

--- a/aldryn_reversion/tests/test_utils.py
+++ b/aldryn_reversion/tests/test_utils.py
@@ -84,8 +84,10 @@ class UtilsTestCase(HelperModelsObjectsSetupMixin, ReversionBaseTestCase):
         # check that object has 2 translation already
         self.assertEqual(self.with_translation.translations.count(), 2)
         # get_for_object returns latest version first.
-        version_2 = default_revision_manager.get_for_object(self.with_translation)[0]
-        version_1 = default_revision_manager.get_for_object(self.with_translation)[1]
+        version_2 = default_revision_manager.get_for_object(
+            self.with_translation)[0]
+        version_1 = default_revision_manager.get_for_object(
+            self.with_translation)[1]
         revision_2 = version_2.revision
         revision_1 = version_1.revision
         # compare count of translations from latest revision to actual count
@@ -111,7 +113,8 @@ class UtilsTestCase(HelperModelsObjectsSetupMixin, ReversionBaseTestCase):
         self.assertEqual(len(result_versions), 1)
 
     def test_get_deleted_objects_versions(self):
-        blank_fk_version = default_revision_manager.get_for_object(self.blank_fk)[0]
+        blank_fk_version = default_revision_manager.get_for_object(
+            self.blank_fk)[0]
         blank_fk_pk = self.blank_fk.pk
         # ensure that returns nothing for not deleted objects
         result = get_deleted_objects_versions(
@@ -129,7 +132,8 @@ class UtilsTestCase(HelperModelsObjectsSetupMixin, ReversionBaseTestCase):
         self.assertEqual(result[0].object_id_int, blank_fk_pk)
 
         # test with mixing 2 deleted object Versions
-        simple_fk_version = default_revision_manager.get_for_object(self.simple_fk)[0]
+        simple_fk_version = default_revision_manager.get_for_object(
+            self.simple_fk)[0]
         simple_fk_pk = self.simple_fk.pk
         self.simple_fk.delete()
         self.assertEqual(SimpleFK.objects.filter(pk=simple_fk_pk).count(), 0)
@@ -153,7 +157,8 @@ class UtilsTestCase(HelperModelsObjectsSetupMixin, ReversionBaseTestCase):
         self.assertEqual(len(result), 0)
 
         # test with object that has no conflicts
-        simple_fk_version = default_revision_manager.get_for_object(self.simple_fk)[0]
+        simple_fk_version = default_revision_manager.get_for_object(
+            self.simple_fk)[0]
         result = get_conflict_fks_versions(
             self.simple_fk, simple_fk_version, simple_fk_version.revision)
         self.assertEqual(len(result), 0)
@@ -173,7 +178,8 @@ class UtilsTestCase(HelperModelsObjectsSetupMixin, ReversionBaseTestCase):
 
     def test_get_conflict_fks_versions_with_blank_fk_model(self):
         # test with no conflict
-        bank_fk_version = default_revision_manager.get_for_object(self.blank_fk)[0]
+        bank_fk_version = default_revision_manager.get_for_object(
+            self.blank_fk)[0]
         result = get_conflict_fks_versions(
             self.blank_fk, bank_fk_version, bank_fk_version.revision)
         self.assertEqual(len(result), 0)
@@ -189,7 +195,8 @@ class UtilsTestCase(HelperModelsObjectsSetupMixin, ReversionBaseTestCase):
         # test with new blank fk that has no relations, should not have
         # conflicts after delete.
         new_blank_fk = self.create_with_revision(BlankFK)
-        new_blank_fk_version = default_revision_manager.get_for_object(new_blank_fk)[0]
+        new_blank_fk_version = default_revision_manager.get_for_object(
+            new_blank_fk)[0]
         result = get_conflict_fks_versions(
             new_blank_fk, new_blank_fk_version, new_blank_fk_version.revision)
         self.assertEqual(len(result), 0)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 from aldryn_reversion import __version__
 
 REQUIREMENTS = [
-    'Django>=1.6,<1.9',
+    'Django>=1.6,<1.10',
     'django-cms>=3.0.12',
     'django-reversion>=1.8.2,<1.11',
 ]

--- a/test_requirements/django-1.7.txt
+++ b/test_requirements/django-1.7.txt
@@ -1,4 +1,3 @@
 django>=1.7.4,<1.8
-django-reversion>=1.8.2,<1.9
 
 -r base.txt

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -1,4 +1,3 @@
 django>=1.8,<1.9
-django-reversion>=1.9.3,<1.11
 
 -r base.txt

--- a/test_requirements/django-1.9.txt
+++ b/test_requirements/django-1.9.txt
@@ -1,4 +1,3 @@
 django>=1.9,<1.10
-django-reversion>=1.9.3,<1.11
 
 -r base.txt

--- a/test_requirements/django-1.9.txt
+++ b/test_requirements/django-1.9.txt
@@ -1,0 +1,4 @@
+django>=1.9,<1.10
+django-reversion>=1.9.3,<1.11
+
+-r base.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
 envlist =
     flake8,
+    py34-dj19-cms32
     py{34}-dj{18,17}-cms{32,31,30},
+    py27-dj19-cms32
     py{27}-dj{18,17,16}-cms{32,31,30},
     py{26}-dj{16}-cms{32,31,30}
 
@@ -15,11 +17,11 @@ deps =
     dj16: -rtest_requirements/django-1.6.txt
     dj17: -rtest_requirements/django-1.7.txt
     dj18: -rtest_requirements/django-1.8.txt
+    dj19: -rtest_requirements/django-1.9.txt
     cms30: django-cms<3.1
     cms31: django-cms<3.2
     cms32: django-cms<3.3
     py26: unittest2
-
     djangocms_text_ckeditor
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,11 @@
 envlist =
     flake8,
     py34-dj19-cms32
-    py{34}-dj{18,17}-cms{32,31,30},
+    py34-dj{18,17}-cms{32,31}
+    py34-dj17-cms30
     py27-dj19-cms32
-    py{27}-dj{18,17,16}-cms{32,31,30},
+    py27-dj{18,17,16}-cms{32,31}
+    py27-dj16-cms30
     py{26}-dj{16}-cms{32,31,30}
 
 [testenv]
@@ -19,8 +21,11 @@ deps =
     dj18: -rtest_requirements/django-1.8.txt
     dj19: -rtest_requirements/django-1.9.txt
     cms30: django-cms<3.1
+    dj17-cms30: django-reversion<1.9
     cms31: django-cms<3.2
+    dj{18,17}-cms31: django-reversion<1.10
     cms32: django-cms<3.3
+    dj{19,18,17}-cms32: django-reversion<1.11
     py26: unittest2
     djangocms_text_ckeditor
 


### PR DESCRIPTION
Depends on https://github.com/divio/django-cms/pull/4812 since it introduces ``Django 1.9`` support in cms itself.