### PR TITLE
Django 1.9 and reversion 1.10 fixes

### DIFF
--- a/aldryn_reversion/admin.py
+++ b/aldryn_reversion/admin.py
@@ -182,6 +182,9 @@ class VersionedPlaceholderAdminMixin(PlaceholderAdminMixin, VersionAdmin):
         if REVERSION_1_9_OR_HIGHER:
             class_super = VersionedPlaceholderAdminMixin
         else:
+            # Prior to django-reversion 1.9.0 there were no way to change
+            # initial comment, but we still need call super to invoke django's
+            # log_addition and avoid django-reversion log_addition.
             class_super = VersionAdmin
         try:
             super(class_super, self).log_addition(request, obj, comment)

--- a/aldryn_reversion/test_helpers/project/test_app/admin.py
+++ b/aldryn_reversion/test_helpers/project/test_app/admin.py
@@ -15,7 +15,7 @@ from .models import (
 
 
 class SimpleRegisteredAdmin(VersionedPlaceholderAdminMixin, admin.ModelAdmin):
-    pass
+    list_display = ('pk', 'position')
 
 
 class WithTranslationsAdmin(VersionedPlaceholderAdminMixin,

--- a/aldryn_reversion/tests/base.py
+++ b/aldryn_reversion/tests/base.py
@@ -75,7 +75,7 @@ class ReversionBaseTestCase(TransactionTestCase):
 
     def create_super_user(self, user_name, user_password):
         super_user = self.create_user(user_name, user_password,
-                                      is_superuser=True)
+                                      is_superuser=True, is_staff=True)
         return super_user
 
     def create_with_revision(self, kls, language='en', **kwargs):

--- a/aldryn_reversion/tests/test_admin_views.py
+++ b/aldryn_reversion/tests/test_admin_views.py
@@ -9,6 +9,7 @@ from reversion.revisions import (
 
 from django.contrib import admin
 from django.core.urlresolvers import reverse, NoReverseMatch
+from django.test import Client
 
 from cms import api
 
@@ -358,6 +359,24 @@ class ReversionRevisionAdminTestCase(AdminUtilsMixin,
         self.simple_registered = SimpleRegistered.objects.get(
             pk=self.simple_registered.pk)
         self.assertEquals(self.simple_registered.position, initial_position)
+
+    def test_admin_create_obj_view(self):
+        """Test that admin create view works and actually creates an object"""
+        obj_count = SimpleRegistered.objects.count()
+        obj = SimpleRegistered.objects.first()
+        url = reverse(
+            'admin:{0}_{1}_{2}'.format(
+                obj._meta.app_label,
+                obj._meta.model_name,
+                'add'))
+        client = Client()
+        # TODO: we can replace this with force_login() on Django 1.9+
+        client.login(username=self.super_user.username,
+                     password=self.super_user_password)
+        position = '777'
+        response = client.post(url, data={'position': position}, follow=True)
+        self.assertEqual(obj_count, SimpleRegistered.objects.count() - 1)
+        self.assertContains(response, position)
 
 
 class AdminUtilsMethodsTestCase(AdminUtilsMixin,


### PR DESCRIPTION
Django 1.9 and reversion 1.10 fixes

 * Tests: create superuser with is_staff flag on
 * Add test case for admin create view